### PR TITLE
Remove help text

### DIFF
--- a/src/new_game.c
+++ b/src/new_game.c
@@ -65,7 +65,7 @@ static void SetDefaultOptions(void)
     gSaveBlock2Ptr->optionsBattleStyle = OPTIONS_BATTLE_STYLE_SHIFT;
     gSaveBlock2Ptr->optionsBattleSceneOff = FALSE;
     gSaveBlock2Ptr->regionMapZoom = FALSE;
-    gSaveBlock2Ptr->optionsButtonMode = OPTIONS_BUTTON_MODE_HELP;
+    gSaveBlock2Ptr->optionsButtonMode = OPTIONS_BUTTON_MODE_LR;
 }
 
 static void ClearPokedexFlags(void)

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -111,6 +111,7 @@ void NewGameInitData(void)
     StringCopy(rivalName, gSaveBlock1Ptr->rivalName);
     gDifferentSaveFile = TRUE;
     gSaveBlock2Ptr->encryptionKey = 0;
+    gSaveBlock2Ptr->optionsButtonMode = OPTIONS_BUTTON_MODE_LR;
     ZeroPlayerPartyMons();
     ZeroEnemyPartyMons();
     ClearBattleTower();

--- a/src/oak_speech.c
+++ b/src/oak_speech.c
@@ -563,23 +563,24 @@ static void Task_OaksSpeech1(u8 taskId)
         CopyBgTilemapBufferToVram(1);
         break;
     case 7:
-        CreateTopBarWindowLoadPalette(0, 30, 0, 13, 0x1C4);
-        FillBgTilemapBufferRect_Palette0(1, 0xD00F,  0,  0, 30, 2);
-        FillBgTilemapBufferRect_Palette0(1, 0xD002,  0,  2, 30, 1);
-        FillBgTilemapBufferRect_Palette0(1, 0xD00E,  0, 19, 30, 1);
-        CreateHelpDocsPage1();
+        //CreateTopBarWindowLoadPalette(0, 30, 0, 13, 0x1C4);
+        //FillBgTilemapBufferRect_Palette0(1, 0xD00F,  0,  0, 30, 2);
+        //FillBgTilemapBufferRect_Palette0(1, 0xD002,  0,  2, 30, 1);
+        //FillBgTilemapBufferRect_Palette0(1, 0xD00E,  0, 19, 30, 1);
+        //CreateHelpDocsPage1();
         gPaletteFade.bufferTransferDisabled = FALSE;
-        gTasks[taskId].data[5] = CreateTextCursorSpriteForOakSpeech(0, 0xE6, 0x95, 0, 0);
+        //gTasks[taskId].data[5] = CreateTextCursorSpriteForOakSpeech(0, 0xE6, 0x95, 0, 0);
         BlendPalettes(PALETTES_ALL, 0x10, 0x00);
         break;
     case 10:
-        BeginNormalPaletteFade(PALETTES_ALL, 0, 16, 0, RGB_BLACK);
+        //BeginNormalPaletteFade(PALETTES_ALL, 0, 16, 0, RGB_BLACK);
         SetGpuReg(REG_OFFSET_DISPCNT, DISPCNT_MODE_0 | DISPCNT_OBJ_1D_MAP | DISPCNT_OBJ_ON);
         ShowBg(0);
         ShowBg(1);
         SetVBlankCallback(VBlankCB_NewGameOaksSpeech);
-        PlayBGM(MUS_NEW_GAME_INSTRUCT);
-        gTasks[taskId].func = Task_OaksSpeech2;
+        //PlayBGM(MUS_NEW_GAME_INSTRUCT);
+        //gTasks[taskId].func = Task_OaksSpeech2;
+        gTasks[taskId].func = Task_OakSpeech9;
         gMain.state = 0;
         return;
     }

--- a/src/quest_log.c
+++ b/src/quest_log.c
@@ -418,7 +418,7 @@ void TrySetUpQuestLogScenes_ElseContinueFromSave(u8 taskId)
     u8 i;
 
     QL_EnableRecordingSteps();
-    sNumScenes = 0;
+    /*sNumScenes = 0;
     for (i = 0; i < QUEST_LOG_SCENE_COUNT; i++)
     {
         if (gSaveBlock1Ptr->questLog[i].startType != 0)
@@ -432,10 +432,10 @@ void TrySetUpQuestLogScenes_ElseContinueFromSave(u8 taskId)
         DestroyTask(taskId);
     }
     else
-    {
+    {*/
         SetMainCallback2(CB2_ContinueSavedGame);
         DestroyTask(taskId);
-    }
+    //}
 }
 
 static void Task_BeginQuestLogPlayback(u8 taskId)


### PR DESCRIPTION
Removes Button Tutorial and intro so New Games jump straight to Oaks Speach.

Also changes the default Button Mode from "Help" to "LR" which does the following:
- removes the help box from the start menu
- allows L/R buttons to be used for other things
- can be changed back in the Options menu if player decides they want the help menu functionality for some reason.